### PR TITLE
Move effect rows to the outside

### DIFF
--- a/src/Halogen/VDom.purs
+++ b/src/Halogen/VDom.purs
@@ -4,6 +4,6 @@ module Halogen.VDom
   , module Types
   ) where
 
-import Halogen.VDom.DOM (VDomEff, VDomMachine, VDomStep, VDomSpec(..), buildVDom) as DOM
+import Halogen.VDom.DOM (VDomMachine, VDomStep, VDomSpec(..), buildVDom) as DOM
 import Halogen.VDom.Machine (Machine, Step(..), extract, step, halt) as Machine
 import Halogen.VDom.Types (VDom(..), Graft, runGraft, ElemSpec(..), ElemName(..), Namespace(..)) as Types

--- a/src/Halogen/VDom/DOM.purs
+++ b/src/Halogen/VDom/DOM.purs
@@ -1,6 +1,5 @@
 module Halogen.VDom.DOM
-  ( VDomEff
-  , VDomMachine
+  ( VDomMachine
   , VDomStep
   , VDomSpec(..)
   , buildVDom
@@ -28,11 +27,9 @@ import Halogen.VDom.Util (forE, forInE, whenE, diffWithIxE, diffWithKeyAndIxE, s
 
 data Quaple a b c d = Quaple a b c d
 
-type VDomEff eff = Eff (dom ∷ DOM | eff)
+type VDomMachine eff a b = Machine (Eff eff) a b
 
-type VDomMachine eff a b = Machine (VDomEff eff) a b
-
-type VDomStep eff a b = VDomEff eff (Step (VDomEff eff) a b)
+type VDomStep eff a b = Eff eff (Step (Eff eff) a b)
 
 newtype VDomSpec eff a w = VDomSpec
   { buildWidget ∷ VDomSpec eff a w → VDomMachine eff w DOM.Node
@@ -42,8 +39,8 @@ newtype VDomSpec eff a w = VDomSpec
 
 buildVDom
   ∷ ∀ eff a w
-  . VDomSpec eff a w
-  → VDomMachine eff (VDom a w) DOM.Node
+  . VDomSpec (dom ∷ DOM | eff) a w
+  → VDomMachine (dom ∷ DOM | eff) (VDom a w) DOM.Node
 buildVDom spec = render
   where
   render = case _ of
@@ -55,9 +52,9 @@ buildVDom spec = render
 
 buildText
   ∷ ∀ eff a w
-  . VDomSpec eff a w
+  . VDomSpec (dom ∷ DOM | eff) a w
   → String
-  → VDomStep eff (VDom a w) DOM.Node
+  → VDomStep (dom ∷ DOM | eff) (VDom a w) DOM.Node
 buildText (VDomSpec spec) = render
   where
   render s = do
@@ -78,10 +75,10 @@ buildText (VDomSpec spec) = render
 
 buildElem
   ∷ ∀ eff a w
-  . VDomSpec eff a w
+  . VDomSpec (dom ∷ DOM | eff) a w
   → ElemSpec a
   → Array (VDom a w)
-  → VDomStep eff (VDom a w) DOM.Node
+  → VDomStep (dom ∷ DOM | eff) (VDom a w) DOM.Node
 buildElem (VDomSpec spec) = render
   where
   render es1@(ElemSpec ns1 name1 as1) ch1 = do
@@ -132,10 +129,10 @@ buildElem (VDomSpec spec) = render
 
 buildKeyed
   ∷ ∀ eff a w
-  . VDomSpec eff a w
+  . VDomSpec (dom ∷ DOM | eff) a w
   → ElemSpec a
   → Array (Tuple String (VDom a w))
-  → VDomStep eff (VDom a w) DOM.Node
+  → VDomStep (dom ∷ DOM | eff) (VDom a w) DOM.Node
 buildKeyed (VDomSpec spec) = render
   where
   render es1@(ElemSpec ns1 name1 as1) ch1 = do
@@ -192,9 +189,9 @@ buildKeyed (VDomSpec spec) = render
 
 buildWidget
   ∷ ∀ eff a w
-  . VDomSpec eff a w
+  . VDomSpec (dom ∷ DOM | eff) a w
   → w
-  → VDomStep eff (VDom a w) DOM.Node
+  → VDomStep (dom ∷ DOM | eff) (VDom a w) DOM.Node
 buildWidget (VDomSpec spec) = render
   where
   render w = do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -108,8 +108,8 @@ renderData st =
 
 buildWidget
   ∷ ∀ eff
-  . V.VDomSpec eff (Array Attribute) (Exists Thunk)
-  → V.VDomMachine eff (Exists Thunk) DOM.Node
+  . V.VDomSpec (dom ∷ DOM | eff) (Array Attribute) (Exists Thunk)
+  → V.VDomMachine (dom ∷ DOM | eff) (Exists Thunk) DOM.Node
 buildWidget spec = render
   where
   render = runExists \(Thunk a render) → do
@@ -126,7 +126,7 @@ buildWidget spec = render
 buildAttributes
   ∷ ∀ eff
   . DOM.Element
-  → V.VDomMachine eff (Array Attribute) Unit
+  → V.VDomMachine (dom ∷ DOM | eff) (Array Attribute) Unit
 buildAttributes el = render
   where
   render as1 = do
@@ -155,7 +155,7 @@ buildAttributes el = render
 mkSpec
   ∷ ∀ eff
   . DOM.Document
-  → V.VDomSpec eff (Array Attribute) (Exists Thunk)
+  → V.VDomSpec (dom ∷ DOM | eff) (Array Attribute) (Exists Thunk)
 mkSpec document = V.VDomSpec
   { buildWidget
   , buildAttributes
@@ -174,11 +174,11 @@ foreign import requestAnimationFrame ∷ ∀ eff. Eff (dom ∷ DOM | eff) Unit �
 
 mkRenderQueue
   ∷ ∀ eff a
-  . V.VDomSpec (ref ∷ REF | eff) (Array Attribute) (Exists Thunk)
+  . V.VDomSpec (dom ∷ DOM, ref ∷ REF | eff) (Array Attribute) (Exists Thunk)
   → DOM.Node
   → (a → VDom)
   → a
-  → V.VDomEff (ref ∷ REF | eff) (a → V.VDomEff (ref ∷ REF | eff) Unit)
+  → Eff (dom ∷ DOM, ref ∷ REF | eff) (a → Eff (dom ∷ DOM, ref ∷ REF | eff) Unit)
 mkRenderQueue spec parent render initialValue = do
   initMachine ← V.buildVDom spec (render initialValue)
   DOM.appendChild (V.extract initMachine) parent
@@ -196,11 +196,11 @@ mkRenderQueue spec parent render initialValue = do
 
 mkRenderQueue'
   ∷ ∀ eff a
-  . V.VDomSpec (ref ∷ REF | eff) (Array Attribute) (Exists Thunk)
+  . V.VDomSpec (dom ∷ DOM, ref ∷ REF | eff) (Array Attribute) (Exists Thunk)
   → DOM.Node
   → (a → VDom)
   → a
-  → V.VDomEff (ref ∷ REF | eff) (a → V.VDomEff (ref ∷ REF | eff) Unit)
+  → Eff (dom ∷ DOM, ref ∷ REF | eff) (a → Eff (dom ∷ DOM, ref ∷ REF | eff) Unit)
 mkRenderQueue' spec parent render initialValue = do
   initMachine ← V.buildVDom spec (render initialValue)
   DOM.appendChild (V.extract initMachine) parent


### PR DESCRIPTION
This kinda sucks, but I think the types are harder to get right when `DOM` is wedged into the synonyms. Or if not harder, more annoying anyway... :wink: