### PR TITLE
Pervasive unsafe effects

### DIFF
--- a/src/Halogen/VDom/Util.js
+++ b/src/Halogen/VDom/Util.js
@@ -9,180 +9,147 @@ exports.unsafeHasAny = function (key, obj) {
 };
 
 exports.unsafeSetAny = function (key, val, obj) {
-  return function () {
-    obj[key] = val;
-  };
+  obj[key] = val;
 };
 
 exports.unsafeDeleteAny = function (key, obj) {
-  return function () {
-    delete obj[key];
-  };
+  delete obj[key];
 };
 
-exports.forE = function (a, f) {
-  return function () {
-    var b = [];
-    for (var i = 0; i < a.length; i++) {
-      b.push(f(i, a[i])());
-    }
-    return b;
-  };
+exports.unsafeForE = function (a, f) {
+  var b = [];
+  for (var i = 0; i < a.length; i++) {
+    b.push(f(i, a[i])());
+  }
+  return b;
 };
 
-exports.forInE = function (o, f) {
-  return function () {
-    var ks = Object.keys(o);
-    for (var i = 0; i < ks.length; i++) {
-      var k = ks[i];
-      f(k, o[k])();
-    }
-  };
+exports.unsafeForInE = function (o, f) {
+  var ks = Object.keys(o);
+  for (var i = 0; i < ks.length; i++) {
+    var k = ks[i];
+    f(k, o[k])();
+  }
 };
 
-exports.replicateE = function (n, f) {
-  return function () {
-    for (var i = 0; i < n; i++) {
-      f();
-    }
-  };
+exports.unsafeReplicateE = function (n, f) {
+  for (var i = 0; i < n; i++) {
+    f();
+  }
 };
 
-exports.diffWithIxE = function (a1, a2, f1, f2, f3) {
-  return function () {
-    var a3 = [];
-    var l1 = a1.length;
-    var l2 = a2.length;
-    var i  = 0;
-    while (1) {
-      if (i < l1) {
-        if (i < l2) {
-          a3.push(f1(i, a1[i], a2[i])());
-        } else {
-          f2(i, a1[i])();
-        }
-      } else if (i < l2) {
-        a3.push(f3(i, a2[i])());
+exports.unsafeDiffWithIxE = function (a1, a2, f1, f2, f3) {
+  var a3 = [];
+  var l1 = a1.length;
+  var l2 = a2.length;
+  var i  = 0;
+  while (1) {
+    if (i < l1) {
+      if (i < l2) {
+        a3.push(f1(i, a1[i], a2[i])());
       } else {
-        break;
+        f2(i, a1[i])();
       }
-      i++;
+    } else if (i < l2) {
+      a3.push(f3(i, a2[i])());
+    } else {
+      break;
     }
-    return a3;
-  };
+    i++;
+  }
+  return a3;
 };
 
-exports.strMapWithIxE = function (as, fk, f) {
-  return function () {
-    var o = {};
-    for (var i = 0; i < as.length; i++) {
-      var a = as[i];
-      var k = fk(a);
-      o[k] = f(k, i, a)();
-    }
-    return o;
-  };
+exports.unsafeStrMapWithIxE = function (as, fk, f) {
+  var o = {};
+  for (var i = 0; i < as.length; i++) {
+    var a = as[i];
+    var k = fk(a);
+    o[k] = f(k, i, a)();
+  }
+  return o;
 };
 
-exports.diffWithKeyAndIxE = function (o1, as, fk, f1, f2, f3) {
-  return function () {
-    var o2 = {};
-    for (var i = 0; i < as.length; i++) {
-      var a = as[i];
-      var k = fk(a);
-      if (o1.hasOwnProperty(k)) {
-        o2[k] = f1(k, i, o1[k], a)();
-      } else {
-        o2[k] = f3(k, i, a)();
-      }
+exports.unsafeDiffWithKeyAndIxE = function (o1, as, fk, f1, f2, f3) {
+  var o2 = {};
+  for (var i = 0; i < as.length; i++) {
+    var a = as[i];
+    var k = fk(a);
+    if (o1.hasOwnProperty(k)) {
+      o2[k] = f1(k, i, o1[k], a)();
+    } else {
+      o2[k] = f3(k, i, a)();
     }
-    for (var k in o1) {
-      if (k in o2) {
-        continue;
-      }
-      f2(k, o1[k])();
+  }
+  for (var k in o1) {
+    if (k in o2) {
+      continue;
     }
-    return o2;
-  };
+    f2(k, o1[k])();
+  }
+  return o2;
 };
 
 exports.refEq = function (a, b) {
   return a === b;
 };
 
-exports.createTextNode = function (s, doc) {
-  return function () {
-    return doc.createTextNode(s);
-  };
+exports.unsafeCreateTextNode = function (s, doc) {
+  return doc.createTextNode(s);
 };
 
-exports.setTextContent = function (s, n) {
-  return function () {
-    n.textContent = s;
-  };
+exports.unsafeSetTextContent = function (s, n) {
+  n.textContent = s;
 };
 
-exports.createElement = function (ns, name, doc) {
-  return function () {
-    if (ns != null) {
-      return doc.createElementNS(ns, name);
-    } else {
-      return doc.createElement(name)
-    }
-  };
+
+exports.unsafeCreateElement = function (ns, name, doc) {
+  if (ns != null) {
+    return doc.createElementNS(ns, name);
+  } else {
+    return doc.createElement(name)
+  }
 };
 
-exports.insertChildIx = function (i, a, b) {
-  return function () {
-    var n = b.childNodes.item(i) || null;
-    if (n !== a) {
-      b.insertBefore(a, n);
-    }
-  };
+exports.unsafeInsertChildIx = function (i, a, b) {
+  var n = b.childNodes.item(i) || null;
+  if (n !== a) {
+    b.insertBefore(a, n);
+  }
 };
 
-exports.removeChild = function (a, b) {
-  return function () {
-    if (b && a.parentNode === b) {
-      b.removeChild(a);
-    }
-  };
+exports.unsafeRemoveChild = function (a, b) {
+  if (b && a.parentNode === b) {
+    b.removeChild(a);
+  }
 };
 
 exports.unsafeParent = function (a) {
   return a.parentNode;
 };
 
-exports.setAttribute = function (ns, attr, val, el) {
-  return function () {
-    if (ns != null) {
-      el.setAttributeNS(ns, attr, val);
-    } else {
-      el.setAttribute(attr, val);
-    }
-  };
+exports.unsafeSetAttribute = function (ns, attr, val, el) {
+  if (ns != null) {
+    el.setAttributeNS(ns, attr, val);
+  } else {
+    el.setAttribute(attr, val);
+  }
 };
 
-exports.removeAttribute = function (ns, attr, el) {
-  return function () {
-    if (ns != null) {
-      el.removeAttributeNS(ns, attr);
-    } else {
-      el.removeAttribute(attr);
-    }
-  };
+exports.unsafeRemoveAttribute = function (ns, attr, el) {
+  if (ns != null) {
+    el.removeAttributeNS(ns, attr);
+  } else {
+    el.removeAttribute(attr);
+  }
 };
 
-exports.addEventListener = function (ev, listener, el) {
-  return function () {
-    el.addEventListener(ev, listener, false);
-  };
+exports.unsafeAddEventListener = function (ev, listener, el) {
+  el.addEventListener(ev, listener, false);
 };
 
-exports.removeEventListener = function (ev, listener, el) {
-  return function () {
-    el.removeEventListener(ev, listener, false);
-  };
+exports.unsafeRemoveEventListener = function (ev, listener, el) {
+  el.removeEventListener(ev, listener, false);
 };
 
 exports.jsUndefined = void 0;

--- a/src/Halogen/VDom/Util.purs
+++ b/src/Halogen/VDom/Util.purs
@@ -2,39 +2,38 @@ module Halogen.VDom.Util
   ( effPure
   , effUnit
   , MutStrMap
-  , newMutMap
-  , pokeMutMap
-  , deleteMutMap
+  , unsafeNewMutMap
+  , unsafePokeMutMap
+  , unsafeDeleteMutMap
   , unsafeFreeze
   , unsafeLookup
   , unsafeGetAny
   , unsafeHasAny
   , unsafeSetAny
   , unsafeDeleteAny
-  , forE
-  , forInE
-  , replicateE
-  , diffWithIxE
-  , diffWithKeyAndIxE
-  , strMapWithIxE
+  , unsafeForE
+  , unsafeForInE
+  , unsafeReplicateE
+  , unsafeDiffWithIxE
+  , unsafeDiffWithKeyAndIxE
+  , unsafeStrMapWithIxE
   , refEq
-  , createTextNode
-  , setTextContent
-  , createElement
-  , insertChildIx
-  , removeChild
+  , unsafeCreateTextNode
+  , unsafeSetTextContent
+  , unsafeCreateElement
+  , unsafeInsertChildIx
+  , unsafeRemoveChild
   , unsafeParent
-  , setAttribute
-  , removeAttribute
-  , addEventListener
-  , removeEventListener
+  , unsafeSetAttribute
+  , unsafeRemoveAttribute
+  , unsafeAddEventListener
+  , unsafeRemoveEventListener
   , JsUndefined
   , jsUndefined
   ) where
 
 import Prelude
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Ref (REF)
 import Data.Function.Uncurried as Fn
 import Data.Nullable (Nullable)
 import Data.StrMap (StrMap)
@@ -55,14 +54,14 @@ effUnit = pure unit
 
 type MutStrMap = STStrMap Void
 
-newMutMap ∷ ∀ eff a. Eff (ref ∷ REF | eff) (MutStrMap a)
-newMutMap = unsafeCoerce STStrMap.new
+unsafeNewMutMap ∷ ∀ a. MutStrMap a
+unsafeNewMutMap = unsafeCoerce STStrMap.new
 
-pokeMutMap ∷ ∀ eff a. Fn.Fn3 String a (MutStrMap a) (Eff (ref ∷ REF | eff) Unit)
-pokeMutMap = unsafeSetAny
+unsafePokeMutMap ∷ ∀ a. Fn.Fn3 String a (MutStrMap a) Unit
+unsafePokeMutMap = unsafeSetAny
 
-deleteMutMap ∷ ∀ eff a. Fn.Fn2 String (MutStrMap a) (Eff (ref ∷ REF | eff) Unit)
-deleteMutMap = unsafeDeleteAny
+unsafeDeleteMutMap ∷ ∀ a. Fn.Fn2 String (MutStrMap a) Unit
+unsafeDeleteMutMap = unsafeDeleteAny
 
 unsafeFreeze ∷ ∀ a. MutStrMap a → StrMap a
 unsafeFreeze = unsafeCoerce
@@ -77,33 +76,33 @@ foreign import unsafeHasAny
   ∷ ∀ a. Fn.Fn2 String a Boolean
 
 foreign import unsafeSetAny
-  ∷ ∀ eff a b. Fn.Fn3 String a b (Eff eff Unit)
+  ∷ ∀ a b. Fn.Fn3 String a b Unit
 
 foreign import unsafeDeleteAny
-  ∷ ∀ eff a. Fn.Fn2 String a (Eff eff Unit)
+  ∷ ∀ a. Fn.Fn2 String a Unit
 
-foreign import forE
+foreign import unsafeForE
   ∷ ∀ eff a b
   . Fn.Fn2
       (Array a)
       (Fn.Fn2 Int a (Eff eff b))
-      (Eff eff (Array b))
+      (Array b)
 
-foreign import forInE
+foreign import unsafeForInE
   ∷ ∀ eff a
   . Fn.Fn2
       (StrMap.StrMap a)
       (Fn.Fn2 String a (Eff eff Unit))
-      (Eff eff Unit)
+      Unit
 
-foreign import replicateE
+foreign import unsafeReplicateE
   ∷ ∀ eff a
   . Fn.Fn2
       Int
       (Eff eff a)
-      (Eff eff Unit)
+      Unit
 
-foreign import diffWithIxE
+foreign import unsafeDiffWithIxE
   ∷ ∀ eff b c d
   . Fn.Fn5
       (Array b)
@@ -111,9 +110,9 @@ foreign import diffWithIxE
       (Fn.Fn3 Int b c (Eff eff d))
       (Fn.Fn2 Int b (Eff eff Unit))
       (Fn.Fn2 Int c (Eff eff d))
-      (Eff eff (Array d))
+      (Array d)
 
-foreign import diffWithKeyAndIxE
+foreign import unsafeDiffWithKeyAndIxE
   ∷ ∀ eff a b c d
   . Fn.Fn6
       (StrMap.StrMap a)
@@ -122,53 +121,48 @@ foreign import diffWithKeyAndIxE
       (Fn.Fn4 String Int a b (Eff eff c))
       (Fn.Fn2 String a (Eff eff d))
       (Fn.Fn3 String Int b (Eff eff c))
-      (Eff eff (StrMap.StrMap c))
+      (StrMap.StrMap c)
 
-foreign import strMapWithIxE
+foreign import unsafeStrMapWithIxE
   ∷ ∀ eff a b
   . Fn.Fn3
       (Array a)
       (a → String)
       (Fn.Fn3 String Int a (Eff eff b))
-      (Eff eff (StrMap.StrMap b))
+      (StrMap.StrMap b)
 
 foreign import refEq
   ∷ ∀ a b. Fn.Fn2 a b Boolean
 
-foreign import createTextNode
-  ∷ ∀ eff
-  . Fn.Fn2 String DOM.Document (Eff (dom ∷ DOM | eff) DOM.Node)
+foreign import unsafeCreateTextNode
+  ∷ Fn.Fn2 String DOM.Document DOM.Node
 
-foreign import setTextContent
-  ∷ ∀ eff
-  . Fn.Fn2 String DOM.Node (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeSetTextContent
+  ∷ Fn.Fn2 String DOM.Node Unit
 
-foreign import createElement
-  ∷ ∀ eff
-  . Fn.Fn3 (Nullable Namespace) ElemName DOM.Document (Eff (dom ∷ DOM | eff) DOM.Element)
+foreign import unsafeCreateElement
+  ∷ Fn.Fn3 (Nullable Namespace) ElemName DOM.Document DOM.Element
 
-foreign import insertChildIx
-  ∷ ∀ eff
-  . Fn.Fn3 Int DOM.Node DOM.Node (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeInsertChildIx
+  ∷ Fn.Fn3 Int DOM.Node DOM.Node Unit
 
-foreign import removeChild
-  ∷ ∀ eff
-  . Fn.Fn2 DOM.Node DOM.Node (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeRemoveChild
+  ∷ Fn.Fn2 DOM.Node DOM.Node Unit
 
 foreign import unsafeParent
   ∷ DOM.Node → DOM.Node
 
-foreign import setAttribute
-  ∷ ∀ eff. Fn.Fn4 (Nullable Namespace) String String DOM.Element (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeSetAttribute
+  ∷ Fn.Fn4 (Nullable Namespace) String String DOM.Element Unit
 
-foreign import removeAttribute
-  ∷ ∀ eff. Fn.Fn3 (Nullable Namespace) String DOM.Element (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeRemoveAttribute
+  ∷ Fn.Fn3 (Nullable Namespace) String DOM.Element Unit
 
-foreign import addEventListener
-  ∷ ∀ eff. Fn.Fn3 String (DOM.EventListener (dom ∷ DOM | eff)) DOM.Element (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeAddEventListener
+  ∷ ∀ eff. Fn.Fn3 String (DOM.EventListener (dom ∷ DOM | eff)) DOM.Element Unit
 
-foreign import removeEventListener
-  ∷ ∀ eff. Fn.Fn3 String (DOM.EventListener (dom ∷ DOM | eff)) DOM.Element (Eff (dom ∷ DOM | eff) Unit)
+foreign import unsafeRemoveEventListener
+  ∷ ∀ eff. Fn.Fn3 String (DOM.EventListener (dom ∷ DOM | eff)) DOM.Element Unit
 
 foreign import data JsUndefined ∷ *
 


### PR DESCRIPTION
I'm not necessarily suggesting we use this, but I figured I'd throw it out there. This is a hack that exploits magic-do. All the low-level effects are written with unsafe functions, but by putting them in a do block, and wrapping them with `pure`, the optimizer will still correctly sequence them and remove the `pure` overhead. In my testing (in Chrome), this improves the naive perf test to about 54-59 fps, and the optimized perf test to about 72 fps, which is a sizeable jump.