### PR TITLE
Add 'mapThunk' for a combined hoist/map

### DIFF
--- a/src/Halogen/VDom/Thunk.purs
+++ b/src/Halogen/VDom/Thunk.purs
@@ -3,6 +3,7 @@ module Halogen.VDom.Thunk
   , buildThunk
   , runThunk
   , hoist
+  , mapThunk
   , thunked
   , thunk1
   , thunk2
@@ -32,7 +33,10 @@ instance functorThunk ∷ Functor f ⇒ Functor (Thunk f) where
   map f (Thunk a b c d) = Thunk a b (c >>> map f) d
 
 hoist ∷ ∀ f g. (f ~> g) → Thunk f ~> Thunk g
-hoist k (Thunk a b c d) = Thunk a b (c >>> k) d
+hoist = mapThunk
+
+mapThunk ∷ ∀ f g i j. (f i -> g j) → Thunk f i -> Thunk g j
+mapThunk k (Thunk a b c d) = Thunk a b (c >>> k) d
 
 thunk ∷ ∀ a f i. Fn.Fn4 ThunkId (Fn.Fn2 a a Boolean) (a → f i) a (Thunk f i)
 thunk = Fn.mkFn4 \tid eqFn f a →


### PR DESCRIPTION
Open to name suggestions, I used this as it's the scheme used in transformers for this kind of function.

Motivation is to make the definition of a `Bifunctor surface => Functor (ComponentSlot surface slots m)` a little more sane:

``` purescript
ThunkSlot thunk -> ThunkSlot (Thunk.mapThunk (under Wrap (map f) <<< lmap (map f)) thunk)
```

Instead of:

``` purescript
ThunkSlot thunk -> ThunkSlot (Thunk.hoist (un Wrap) $ map f $ Thunk.hoist (Wrap <<< lmap (map f)) thunk)
```

(`Wrap` is needed because `Functor` is not a superclass of `Bifunctor`, so we can't find an instance for `surface`, and it can't be specified as a constraint without quantified constraints).