### PR TITLE
Fix parse error for purs `0.13.x` on `v3.x.x` series

### DIFF
--- a/src/Halogen/VDom/DOM.purs
+++ b/src/Halogen/VDom/DOM.purs
@@ -97,7 +97,7 @@ buildElem = render
     let
       node = DOMElement.toNode el
       onChild = EFn.mkEffectFn2 \ix child → do
-        res@Step n m h ← EFn.runEffectFn1 build child
+        res@(Step n m h) ← EFn.runEffectFn1 build child
         EFn.runEffectFn3 Util.insertChildIx ix n node
         pure res
     steps ← EFn.runEffectFn2 Util.forE ch1 onChild


### PR DESCRIPTION
As mentioned in #29, the lack of parens causes purs `0.13.x` to fail to parse this file. We wrap it in parens and everything should work like normal.